### PR TITLE
Missing headers and body in HTTP Request with Psr17

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -188,8 +188,12 @@ class Client
 
         list($url, $method, $headers, $body) = $this->prepareRequestMessage($request);
 
+        $psr7Request = Psr17FactoryDiscovery::findRequestFactory()->createRequest($method, $url);
+        foreach($headers as $k=>$v) $psr7Request = $psr7Request->withHeader($k, $v);
+        $psr7Request = $psr7Request->withBody(Psr17FactoryDiscovery::findStreamFactory()->createStream($body));
+
         $psr7Response = $this->httpClient->sendRequest(
-            Psr17FactoryDiscovery::findRequestFactory()->createRequest($method, $url, $headers, $body)
+            $psr7Request
         );
 
         static::$requestCount++;

--- a/src/Client.php
+++ b/src/Client.php
@@ -189,7 +189,9 @@ class Client
         list($url, $method, $headers, $body) = $this->prepareRequestMessage($request);
 
         $psr7Request = Psr17FactoryDiscovery::findRequestFactory()->createRequest($method, $url);
-        foreach($headers as $k=>$v) $psr7Request = $psr7Request->withHeader($k, $v);
+        foreach($headers as $k => $v) {
+            $psr7Request = $psr7Request->withHeader($k, $v);
+        }
         $psr7Request = $psr7Request->withBody(Psr17FactoryDiscovery::findStreamFactory()->createStream($body));
 
         $psr7Response = $this->httpClient->sendRequest(

--- a/src/Client.php
+++ b/src/Client.php
@@ -189,7 +189,7 @@ class Client
         list($url, $method, $headers, $body) = $this->prepareRequestMessage($request);
 
         $psr7Request = Psr17FactoryDiscovery::findRequestFactory()->createRequest($method, $url);
-        foreach($headers as $k => $v) {
+        foreach ($headers as $k => $v) {
             $psr7Request = $psr7Request->withHeader($k, $v);
         }
         $psr7Request = $psr7Request->withBody(Psr17FactoryDiscovery::findStreamFactory()->createStream($body));


### PR DESCRIPTION
When switching to Psr17, the createRequest function only takes $method and $url. The headers and body have to be sent in separately after. This causes all POST requests to fail with permission error since the token is the first missing parameter that is checked.