### PR TITLE
Fix PSR-7 request for Facebook Graph

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -188,14 +188,13 @@ class Client
 
         [$url, $method, $headers, $body] = $this->prepareRequestMessage($request);
 
-        $psrRequest = Psr17FactoryDiscovery::findRequestFactory()->createRequest($method, $url, $headers, $body)
+        $psrRequest = Psr17FactoryDiscovery::findRequestFactory()->createRequest($method, $url)
             ->withBody(Psr17FactoryDiscovery::findStreamFactory()->createStream($body));
 
         foreach ($headers as $headerKey => $headerValue) {
-            $psrRequest->withHeader($headerKey, $headerValue);
+            $psrRequest = $psrRequest->withHeader($headerKey, $headerValue);
         }
-
-
+		
         $psr7Response = $this->httpClient->sendRequest($psrRequest);
 
         static::$requestCount++;


### PR DESCRIPTION
This PR fixes a bug where Facebook was throwing the error ( # 100 ) due to incorrect PSR-7 header calls. The headers are now correctly added with withHeader() and reassigned, as required by PSR-7.

This PR is based on 6.1.2